### PR TITLE
Add .by support to freqs() Progress torward #56

### DIFF
--- a/R/freqs.R
+++ b/R/freqs.R
@@ -81,7 +81,10 @@ freqs <- function(
       )
     }
     by_vars <- names(by_sel)
-    dataset <- dplyr::group_by(dataset, dplyr::across(tidyselect::all_of(by_vars)))
+    dataset <- dplyr::group_by(
+      dataset,
+      dplyr::across(tidyselect::all_of(by_vars))
+    )
   }
 
   # Create logical for if there are weights

--- a/R/freqs.R
+++ b/R/freqs.R
@@ -14,6 +14,7 @@
 #' @param nas_group Boolean, whether or not to include NA values for the grouping variable in the tabulation (default: TRUE).
 #' @param factor_group Boolean, whether or not to convert the grouping variable to a factor and use its labels instead of its underlying numeric values (default: FALSE)
 #' @param unweighted_ns Boolean, whether the 'n' column in the freqs table should be Unweighted while results ARE weighted. This argument can only be used if a wt variable is used. If no weight variable is used, the 'n' column will always be unweighted (default: FALSE).
+#' @param .by <tidy-select> Variables to group by for this operation only. Cannot be used when the dataset is already a grouped data frame.
 #' @param show_missing_levels Boolean, whether to keep response levels with no data (default: TRUE)
 #' @return A dataframe with the variable names, prompts, values, labels, counts,
 #' stats, and resulting calculations.
@@ -35,6 +36,7 @@
 #' df |>
 #'   dplyr::group_by(a) |>
 #'   freqs(b, nas = FALSE, wt = weights)
+#' freqs(df, b, .by = a)
 #'
 #' # Note that percentile = 60 will return an estimate
 #' # of the real number such that 60% of values
@@ -51,6 +53,7 @@
 freqs <- function(
   dataset,
   ...,
+  .by = NULL,
   stat = c("percent", "mean", "median", "min", "max", "quantile", "summary"),
   percentile = NULL,
   nas = TRUE,
@@ -64,6 +67,22 @@ freqs <- function(
 ) {
   # options(warn = -1)
   stat <- rlang::arg_match(stat)
+
+  # .by grouping: resolve tidy-selection and apply as grouping
+  by_sel <- tidyselect::eval_select(rlang::enquo(.by), data = dataset)
+  if (length(by_sel) > 0) {
+    if (dplyr::is.grouped_df(dataset)) {
+      cli::cli_abort(
+        c(
+          "Cannot use {.arg .by} on an already-grouped data frame.",
+          "i" = "Use {.code dplyr::group_by()} or {.arg .by}, not both.",
+          "i" = "The dataset is currently grouped by: {.val {dplyr::group_vars(dataset)}}."
+        )
+      )
+    }
+    by_vars <- names(by_sel)
+    dataset <- dplyr::group_by(dataset, dplyr::across(tidyselect::all_of(by_vars)))
+  }
 
   # Create logical for if there are weights
   weight_null <- dplyr::enquo(wt)
@@ -112,6 +131,9 @@ freqs <- function(
     }
 
     p <- p[p != ""]
+  }
+  if (length(by_sel) > 0) {
+    frequencies <- dplyr::ungroup(frequencies)
   }
   return(as_freq_y2(frequencies, p))
 }

--- a/man/freqs.Rd
+++ b/man/freqs.Rd
@@ -8,6 +8,7 @@
 freqs(
   dataset,
   ...,
+  .by = NULL,
   stat = c("percent", "mean", "median", "min", "max", "quantile", "summary"),
   percentile = NULL,
   nas = TRUE,
@@ -23,6 +24,7 @@ freqs(
 freq(
   dataset,
   ...,
+  .by = NULL,
   stat = c("percent", "mean", "median", "min", "max", "quantile", "summary"),
   percentile = NULL,
   nas = TRUE,
@@ -41,6 +43,8 @@ freq(
 \item{...}{<tidy-select> One or more unquoted expressions separated by commas. Variable names can be used as if they were positions in the data frame, so expressions like x:y can be used to select a range of variables. If nothing
 is specified, the function runs a frequency on every column in given dataset.}
 
+\item{.by}{<tidy-select> Variables to group by for this operation only. Cannot be used when the dataset is already a grouped data frame.}
+
 \item{stat}{Character, stat to run. Currently accepts 'percent,' 'mean,' 'median,' 'min,' 'max,' 'quantile,' and 'summary' (default: 'percent').}
 
 \item{percentile}{Double, for use when stat = 'quantile.' Input should be a real number x such that 0 <= x <= 100. Stands for percentile rank, which is a quantile relative to a 100-point scale. (default:NULL)}
@@ -57,7 +61,7 @@ is specified, the function runs a frequency on every column in given dataset.}
 
 \item{factor_group}{Boolean, whether or not to convert the grouping variable to a factor and use its labels instead of its underlying numeric values (default: FALSE)}
 
-\item{unweighted_ns}{Boolean, whether the 'n' column in the freqs table should be UNweighted while results ARE weighted. This argument can only be used if a wt variable is used. If no weight variable is used, the 'n' column will always be unweighted (default: FALSE).}
+\item{unweighted_ns}{Boolean, whether the 'n' column in the freqs table should be Unweighted while results ARE weighted. This argument can only be used if a wt variable is used. If no weight variable is used, the 'n' column will always be unweighted (default: FALSE).}
 
 \item{show_missing_levels}{Boolean, whether to keep response levels with no data (default: TRUE)}
 }
@@ -72,16 +76,20 @@ Run frequencies for multiple variables
 df <- data.frame(
   a = c(1, 2, 2, 3, 4, 2, NA),
   b = c(1, 2, 2, 3, 4, 1, NA),
+  c = c("Red", "Red", "Blue", NA, NA, NA, "Yellow"),
   weights = c(0.9, 0.9, 1.1, 1.1, 1, 1, 1)
 )
 
 freqs(df, a, b)
 freqs(df, a, b, wt = weights)
+freq(df, a:b)
+freq(df, starts_with('a'), wt = weights)
 freq(df, stat = 'mean', nas = FALSE)
 freq(df, stat = 'mean', nas = FALSE, wt = weights)
 df |>
   dplyr::group_by(a) |>
   freqs(b, nas = FALSE, wt = weights)
+freqs(df, b, .by = a)
 
 # Note that percentile = 60 will return an estimate
 # of the real number such that 60\% of values

--- a/tests/testthat/_snaps/freqs.md
+++ b/tests/testthat/_snaps/freqs.md
@@ -3,7 +3,7 @@
     Code
       freqs(df, a)
     Condition
-      Error in `freqs_original()`:
+      Error in `freqs()`:
       ! Can't select within an unnamed vector.
 
 # Not a dataframe error - matrix
@@ -11,7 +11,7 @@
     Code
       freqs(table, column_a)
     Condition
-      Error in `freqs_original()`:
+      Error in `freqs()`:
       ! Can't select within an unnamed vector.
 
 # Incorrect nas argument

--- a/tests/testthat/_snaps/sig_test_y2().md
+++ b/tests/testthat/_snaps/sig_test_y2().md
@@ -3,7 +3,6 @@
     Code
       sig_test_y2(freqs(dplyr::group_by(mod_df, group), V1), mod_df, group)
     Message
-      Adding missing grouping variables: `group`
       Adding grouped pairwise significance tests for response "-1" for group_var "group"
       Adding grouped pairwise significance tests for response "0" for group_var "group"
       Adding grouped pairwise significance tests for response "1" for group_var "group"
@@ -27,7 +26,6 @@
     Code
       sig_test_y2(freqs(dplyr::group_by(mod_df, group), V1), mod_df, group)
     Message
-      Adding missing grouping variables: `group`
       Adding grouped pairwise significance tests for response "Agree" for group_var "group"
       Adding grouped pairwise significance tests for response "Disagree" for group_var "group"
       Adding grouped pairwise significance tests for response "Neither" for group_var "group"
@@ -51,7 +49,6 @@
     Code
       sig_test_y2(freqs(dplyr::group_by(responses3, group), V1), responses3, group)
     Message
-      Adding missing grouping variables: `group`
       Adding grouped pairwise significance tests for response "Agree" for group_var "group"
       Adding grouped pairwise significance tests for response "Disagree" for group_var "group"
       Adding grouped pairwise significance tests for response "Neither" for group_var "group"
@@ -75,7 +72,6 @@
     Code
       sig_test_y2(freqs(dplyr::group_by(responses3, group), V1), mod_df, group)
     Message
-      Adding missing grouping variables: `group`
       Adding grouped pairwise significance tests for response "Agree" for group_var "group"
       Adding grouped pairwise significance tests for response "Neither" for group_var "group"
       Adding grouped pairwise significance tests for response "Disagree" for group_var "group"
@@ -99,7 +95,6 @@
     Code
       sig_test_y2(freqs(dplyr::group_by(mod_df, group), V1), mod_df, group)
     Message
-      Adding missing grouping variables: `group`
       Adding grouped pairwise significance tests for response "Agree" for group_var "group"
       Adding grouped pairwise significance tests for response "Disagree" for group_var "group"
       Adding grouped pairwise significance tests for response "Neither" for group_var "group"
@@ -123,7 +118,6 @@
     Code
       sig_test_y2(freqs(dplyr::group_by(responses3, group), V1), responses3, group)
     Message
-      Adding missing grouping variables: `group`
       Adding grouped pairwise significance tests for response "Agree" for group_var "group"
       Adding grouped pairwise significance tests for response "Disagree" for group_var "group"
       Adding grouped pairwise significance tests for response "Neither" for group_var "group"
@@ -147,7 +141,6 @@
     Code
       sig_test_y2(freqs(dplyr::group_by(mod_df, group), V1), responses3, group)
     Message
-      Adding missing grouping variables: `group`
       Adding grouped pairwise significance tests for response "Agree" for group_var "group"
       Adding grouped pairwise significance tests for response "Disagree" for group_var "group"
       Adding grouped pairwise significance tests for response "Neither" for group_var "group"
@@ -171,8 +164,6 @@
     Code
       frequencies <- sig_test_y2(freqs(dplyr::group_by(mod_df, group), V1), mod_df,
       group)
-    Message
-      Adding missing grouping variables: `group`
     Condition
       Error in `sig_test_y2()`:
       ! Banner variable "group" is a labelled double; please set "factor_group" equal to TRUE in freqs() for this variable


### PR DESCRIPTION
This PR ads .by support for freqs(). .by uses tidyselect to select variables (as opposed to group_by() which uses data masking). It also groupes only for the freqs() call and automatically ungroups the tibble at the end. 

