### PR TITLE
Fixes problem where a tidyselect function would have no matches and the freq() would throw a weird internal error.

### DIFF
--- a/R/append_ns.R
+++ b/R/append_ns.R
@@ -31,41 +31,41 @@
 #'   )
 #' @export
 append_ns <- function(
-    dataset,
-    append_to = label,
-    by_group_var = FALSE,
-    newline = FALSE
-  ) {
-    label <- NULL
-    character_split <- ' '
-    if (isTRUE(newline)) {
-      character_split <- '\n'
-    }
-
-    if (isFALSE(by_group_var)) {
-      dataset |>
-        dplyr::mutate(
-          '{{append_to}}' := stringr::str_c(
-            {{ append_to }},
-            character_split,
-            '(n = ',
-            as.character(.data$n),
-            ')'
-          )
-        )
-    } else {
-      # by_group_var == TRUE
-      dataset |>
-        dplyr::mutate(
-          n_group = sum(.data$n),
-          '{{append_to}}' := stringr::str_c(
-            {{ append_to }},
-            character_split,
-            '(n = ',
-            as.character(.data$n_group),
-            ')'
-          )
-        ) |>
-        dplyr::select(-'n_group')
-    }
+  dataset,
+  append_to = label,
+  by_group_var = FALSE,
+  newline = FALSE
+) {
+  label <- NULL
+  character_split <- ' '
+  if (isTRUE(newline)) {
+    character_split <- '\n'
   }
+
+  if (isFALSE(by_group_var)) {
+    dataset |>
+      dplyr::mutate(
+        '{{append_to}}' := stringr::str_c(
+          {{ append_to }},
+          character_split,
+          '(n = ',
+          as.character(.data$n),
+          ')'
+        )
+      )
+  } else {
+    # by_group_var == TRUE
+    dataset |>
+      dplyr::mutate(
+        n_group = sum(.data$n),
+        '{{append_to}}' := stringr::str_c(
+          {{ append_to }},
+          character_split,
+          '(n = ',
+          as.character(.data$n_group),
+          ')'
+        )
+      ) |>
+      dplyr::select(-'n_group')
+  }
+}

--- a/R/freqs.R
+++ b/R/freqs.R
@@ -118,6 +118,7 @@ freqs <- function(
   }
 
   #Attach question wordings
+  p <- NULL
   if ('variable' %in% names(frequencies)) {
     vars <- unique(frequencies$variable)
     p <- character(length(vars))
@@ -845,6 +846,11 @@ remove_group_nas <- function(dataset) {
 
 group_rename <- function(dataset) {
   # Assumed, since non-percent calculations aren't grouped dataframes
+  if (!('variable' %in% names(dataset))) {
+    cli::cli_warn("No columns matched selection.")
+    return(dataset)
+  }
+
   grouping_vars <- dataset |>
     dplyr::select(
       -(tidyselect::all_of('variable'):dplyr::last_col())

--- a/tests/testthat/_snaps/freqs.md
+++ b/tests/testthat/_snaps/freqs.md
@@ -177,3 +177,13 @@
       * `q3` has class <character>
       i Convert the variable to numeric first with `as.numeric()`, or use `stat = 'percent'`.
 
+# freqs returns empty if a tidyselect function is used to and does not match any columns
+
+    Code
+      freq(responses, stem("A"))
+    Condition
+      Warning:
+      No columns matched selection.
+    Output
+      # A tibble: 0 x 0
+

--- a/tests/testthat/test-freqs.R
+++ b/tests/testthat/test-freqs.R
@@ -979,3 +979,10 @@ test_that("stat = 'mean' works when GROUPED", {
 
   expect_length(test$group_var, 4)
 })
+
+test_that("freqs returns empty if a tidyselect function is used to and does not match any columns", {
+  expect_snapshot(
+    responses |>
+      freq(stem("A"))
+  )
+})


### PR DESCRIPTION
It now warns and returns a length 0 tibble. This is the way other functions that consume tidyselect functions work. See select(starts_with('non-existant-stem')) as opposed to select('non-existant-variable').