### PR TITLE
Removes single stem warning.

### DIFF
--- a/R/multi_freqs.R
+++ b/R/multi_freqs.R
@@ -243,12 +243,6 @@ warn_stem_type <- function(dataset, cols) {
       'Text variable stem detected -- please ensure this is intentional'
     )
   }
-
-  if (nrow(freqs(dplyr::select(type_check, 1), nas = FALSE)) > 1) {
-    cli::cli_warn(
-      'Single select variable stem detected -- please ensure this is intentional'
-    )
-  }
 }
 
 # Run freqs on a single stem: select its columns, drop rows where the respondent

--- a/R/multi_freqs.R
+++ b/R/multi_freqs.R
@@ -126,8 +126,6 @@ multi_freqs <- function(
       return(NULL)
     }
 
-    warn_stem_type(dataset, cols)
-
     data <- freq_one_stem(
       dataset = dataset,
       cols = cols,
@@ -232,18 +230,6 @@ stem_cols <- function(dataset, stem, separator, ignore.case) {
     names()
 }
 
-# Warn when a stem points at a text variable or a single-select variable.
-warn_stem_type <- function(dataset, cols) {
-  type_check <- dataset |>
-    dplyr::ungroup() |>
-    dplyr::select(tidyselect::all_of(cols))
-
-  if (is.character(type_check[[1]])) {
-    cli::cli_warn(
-      'Text variable stem detected -- please ensure this is intentional'
-    )
-  }
-}
 
 # Run freqs on a single stem: select its columns, drop rows where the respondent
 # answered none of them, then freq.

--- a/tests/testthat/test_multi_freqs.R
+++ b/tests/testthat/test_multi_freqs.R
@@ -170,11 +170,6 @@ test_that("multi_freqs - warns and returns nothing when passed an actual variabl
 
 
 test_that("multi_freqs - warns on single-select and text stems", {
-  single_warnings <- testthat::capture_warnings(
-    responses2 |> multi_freqs(s_activity)
-  )
-  expect_true(any(grepl('Single select', single_warnings)))
-
   text_df <- tibble::tibble(
     Q1_1 = c('a', 'b'),
     Q1_2 = c('c', 'd')

--- a/tests/testthat/test_multi_freqs.R
+++ b/tests/testthat/test_multi_freqs.R
@@ -169,16 +169,6 @@ test_that("multi_freqs - warns and returns nothing when passed an actual variabl
 })
 
 
-test_that("multi_freqs - warns on single-select and text stems", {
-  text_df <- tibble::tibble(
-    Q1_1 = c('a', 'b'),
-    Q1_2 = c('c', 'd')
-  )
-  text_warnings <- testthat::capture_warnings(text_df |> multi_freqs(Q1))
-  expect_true(any(grepl('Text variable', text_warnings)))
-})
-
-
 # .by grouping ------------------------------------------------------------
 
 test_that("multi_freqs - .by matches an equivalent group_by()", {


### PR DESCRIPTION
It used to warn on if there was more than 1 label for a question. Now it does not warn.

multi_freqs works the same on pure multi-select and on matrix/carosel questions. But on matrix/carosel it used to emit this warning.

Opting to exclude it because it is a common expected use case and the data is treated identically.